### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/modules/call_center/README
+++ b/modules/call_center/README
@@ -315,7 +315,7 @@ cc_agent_login("agentX","0");
 
    Total number of calls answered by agents. (counter type)
 
-1.6.1.6. ccg_abandonned_incalls
+1.6.1.6. ccg_abandoned_incalls
 
    Total number of calls terminated by caller before being
    answered by agents. (counter type)

--- a/modules/call_center/call_center.c
+++ b/modules/call_center/call_center.c
@@ -123,7 +123,7 @@ static stat_export_t mod_stats[] = {
 	{"ccg_load",                  STAT_IS_FUNC,   (stat_var**)stg_load             },
 	{"ccg_distributed_incalls",   0,              &stg_dist_incalls                },
 	{"ccg_answered_incalls" ,     0,              &stg_answ_incalls                },
-	{"ccg_abandonned_incalls" ,   0,              &stg_aban_incalls                },
+	{"ccg_abandoned_incalls" ,   0,              &stg_aban_incalls                },
 	{"ccg_onhold_calls",          STAT_NO_RESET,  &stg_onhold_calls                },
 	{"ccg_free_agents",           STAT_IS_FUNC,   (stat_var**)stg_free_agents      },
 	{0,0,0}

--- a/modules/call_center/doc/call_center_admin.xml
+++ b/modules/call_center/doc/call_center_admin.xml
@@ -386,7 +386,7 @@ cc_agent_login("agentX","0");
 		</section>
 
 		<section>
-		<title>ccg_abandonned_incalls</title>
+		<title>ccg_abandoned_incalls</title>
 			<para>
 			Total number of calls terminated by caller before being
 			answered by agents. (counter type)


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            